### PR TITLE
Allow forks of ddev-gitpod-launcher to use Github pages to launch Gitpod with that fork

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -13,7 +13,6 @@
     <div>Code Git Repository</div><input name='DDEV_REPO' value='https://github.com/drud/d9simple'>
   </div>
 </div>
-<input id='generator' type='hidden' value="https://github.com/drud/ddev-gitpod-launcher">
 
 <div style='height: 15px'></div>
 <a id='computedUrl' target="_blank" href=''>Link to run in gitpod.io</a>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,7 +1,6 @@
 document.body.onload = () => {
   const computeString = () => {
     let values = {};
-    generator = document.getElementById("generator").value
     document.getElementById('target').querySelectorAll('[name]').forEach((element) => {
       switch (element.getAttribute('type')) {
         default:
@@ -15,7 +14,7 @@ document.body.onload = () => {
         }
         urlString += encodeURIComponent(key)+'='+encodeURIComponent(values[key]);
       });
-      urlString += ",/" +generator
+      urlString += ",/" + window.location.href
       const link = document.getElementById('computedUrl');
       link.setAttribute('href', urlString);
       // link.textContent = urlString;

--- a/docs/script.js
+++ b/docs/script.js
@@ -14,7 +14,12 @@ document.body.onload = () => {
         }
         urlString += encodeURIComponent(key)+'='+encodeURIComponent(values[key]);
       });
-      urlString += ",/" + window.location.href
+      
+      
+      const owner = window.location.host.split('.')[0]
+      const baseRepo = `https://github.com/` + owner + window.location.pathname
+      urlString += "/" + baseRepo
+      
       const link = document.getElementById('computedUrl');
       link.setAttribute('href', urlString);
       // link.textContent = urlString;


### PR DESCRIPTION
Instead of static value, get current repo's url.

It allows this fork's Github pages - https://shaal.github.io/ddev-gitpod-launcher, to launch Gitpod using the fork's code.

<a href="https://gitpod.io/#https://github.com/drud/ddev-gitpod-launcher/pull/1"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

