### PR TITLE
Update artifacts repository automatically by default, fixes #5

### DIFF
--- a/.gitpod/start_repo.sh
+++ b/.gitpod/start_repo.sh
@@ -8,7 +8,7 @@ set -eu
 export DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
 echo "Checking out repository ${DDEV_REPO}"
 DEFAULT_ARTIFACTS="${DDEV_REPO}-artifacts"
-export DDEV_ARTIFACTS=${DDEV_ARTIFACTS:$DEFAULT_ARTIFACTS}
+export DDEV_ARTIFACTS=${DDEV_ARTIFACTS:-$DEFAULT_ARTIFACTS}
 echo "Attempting to get artifacts from ${DDEV_ARTIFACTS}"
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || echo "Could not check out artifacts repo ${DDEV_ARTIFACTS}"
 reponame=${DDEV_REPO##*/}

--- a/.gitpod/start_repo.sh
+++ b/.gitpod/start_repo.sh
@@ -6,7 +6,8 @@ set -eu
 # Run composer install if there's a composer.json
 # Import artifacts if there's a ${DDEV_REPO}-artifacts repository that can be checked out
 export DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
-DDEV_ARTIFACTS=${DDEV_ARTIFACTS:${DDEV_REPO}-artifacts}
+DEFAULT_ARTIFACTS="${DDEV_REPO}-artifacts"
+export DDEV_ARTIFACTS=${DDEV_ARTIFACTS:$DEFAULT_ARTIFACTS}
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
 reponame=${DDEV_REPO##*/}
 git clone ${DDEV_REPO} ${GITPOD_REPO_ROOT}/${reponame}

--- a/.gitpod/start_repo.sh
+++ b/.gitpod/start_repo.sh
@@ -6,7 +6,7 @@ set -eu
 # Run composer install if there's a composer.json
 # Import artifacts if there's a ${DDEV_REPO}-artifacts repository that can be checked out
 export DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
-DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
+DDEV_ARTIFACTS=${DDEV_ARTIFACTS:${DDEV_REPO}-artifacts}
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
 reponame=${DDEV_REPO##*/}
 git clone ${DDEV_REPO} ${GITPOD_REPO_ROOT}/${reponame}

--- a/.gitpod/start_repo.sh
+++ b/.gitpod/start_repo.sh
@@ -6,9 +6,11 @@ set -eu
 # Run composer install if there's a composer.json
 # Import artifacts if there's a ${DDEV_REPO}-artifacts repository that can be checked out
 export DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
+echo "Checking out repository ${DDEV_REPO}"
 DEFAULT_ARTIFACTS="${DDEV_REPO}-artifacts"
 export DDEV_ARTIFACTS=${DDEV_ARTIFACTS:$DEFAULT_ARTIFACTS}
-git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
+echo "Attempting to get artifacts from ${DDEV_ARTIFACTS}"
+git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || echo "Could not check out artifacts repo ${DDEV_ARTIFACTS}"
 reponame=${DDEV_REPO##*/}
 git clone ${DDEV_REPO} ${GITPOD_REPO_ROOT}/${reponame}
 if [ -d ${GITPOD_REPO_ROOT}/${reponame} ]; then

--- a/docs/index.html
+++ b/docs/index.html
@@ -29,7 +29,11 @@
       Your project (in any reachable GitHub, GitLab, or Bitbucket repository) will be opened in Gitpod.io.
       If a companion artifacts repository exists, database and files will be loaded.
       Read <a href="https://ddev.readthedocs.io/en/latest/users/topics/gitpod">the docs</a>.
+
+      <br /><br />
+      <div>Link used by "Open in Gitpod" button: <div id="ddev-link"></div></div>
     </div>
+
 
   <footer>
       <div class="footer">

--- a/docs/index.html
+++ b/docs/index.html
@@ -19,8 +19,10 @@
       <div id="target">
         <div class='form'>
           <label>Enter a git repository</label>
-          <input name='DDEV_REPO' placeholder="https://github.com/drud/d9simple" value='https://github.com/drud/d9simple'>
+          <input name='DDEV_REPO' id='ddev-repo' placeholder="https://github.com/drud/d9simple" value='https://github.com/drud/d9simple'>
+          <input name='DDEV_ARTIFACTS' id='ddev-artifacts' placeholder="https://github.com/drud/d9simple-artifacts" value='https://github.com/drud/d9simple-artifacts'>
           <a id='computedUrl' rel="nofollow noopener noreferrer" class="button" target="_blank" href=''>Open in Gitpod</a>
+          <label>(optional) Enter a git repository with artifacts</label>
         </div>
       </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,18 +14,21 @@
 
       <h1>ddev Gitpod launcher</h1>
 
-      <h4>Launch and develop any web project in gitpod using ddev!</h4>
+      <h4>Launch and develop any web project in gitpod using <a target="_blank" href="https://ddev.readthedocs.io">DDEV</a>!</h4>
 
       <div id="target">
         <div class='form'>
           <label>Enter a git repository</label>
           <input name='DDEV_REPO' id='ddev-repo' placeholder="https://github.com/drud/d9simple" value='https://github.com/drud/d9simple'>
+          <label>Enter a git repository with artifacts (optional - if it doesn't exist it's ok)</label>
           <input name='DDEV_ARTIFACTS' id='ddev-artifacts' placeholder="https://github.com/drud/d9simple-artifacts" value='https://github.com/drud/d9simple-artifacts'>
           <a id='computedUrl' rel="nofollow noopener noreferrer" class="button" target="_blank" href=''>Open in Gitpod</a>
-          <label>(optional) Enter a git repository with artifacts</label>
         </div>
       </div>
 
+      Your project (in any reachable GitHub, GitLab, or Bitbucket repository) will be opened in Gitpod.io.
+      If a companion artifacts repository exists, database and files will be loaded.
+      Read <a href="https://ddev.readthedocs.io/en/latest/users/topics/gitpod">the docs</a>.
     </div>
 
   <footer>

--- a/docs/script.js
+++ b/docs/script.js
@@ -25,9 +25,16 @@ document.body.onload = () => {
       // link.textContent = urlString;
     })
   }
+  const updateArtifacts = () => {
+    sourceField = document.getElementById("ddev-repo")
+    artifactsField = document.getElementById("ddev-artifacts")
+    artifactsField.value = sourceField.value + "-artifacts"
+  }
+  updateArtifacts();
   computeString();
   document.getElementById('target').querySelectorAll('[name]').forEach((element) => {
     element.addEventListener('change', (e) => {
+      updateArtifacts();
       computeString();
     })
   })

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,5 +1,5 @@
 document.body.onload = () => {
-  const computeString = () => {
+  const computeLink = () => {
     let values = {};
     document.getElementById('target').querySelectorAll('[name]').forEach((element) => {
       switch (element.getAttribute('type')) {
@@ -20,8 +20,8 @@ document.body.onload = () => {
       const baseRepo = `https://github.com/` + owner + window.location.pathname
       urlString += "/" + baseRepo
       
-      const link = document.getElementById('computedUrl');
-      link.setAttribute('href', urlString);
+      document.getElementById('computedUrl').setAttribute('href', urlString);
+      document.getElementById('ddev-link').innerHTML = urlString;
     })
   }
   const updateArtifacts = () => {
@@ -30,11 +30,14 @@ document.body.onload = () => {
     artifactsField.value = sourceField.value + "-artifacts"
   }
   updateArtifacts();
-  computeString();
+  computeLink();
   document.getElementById('target').querySelectorAll('[name]').forEach((element) => {
     element.addEventListener('change', (e) => {
-      updateArtifacts();
-      computeString();
+      computeLink();
     })
   })
+  document.getElementById('ddev-repo').addEventListener('change', (e) => {
+      updateArtifacts();
+    })
+
 }

--- a/docs/script.js
+++ b/docs/script.js
@@ -22,7 +22,6 @@ document.body.onload = () => {
       
       const link = document.getElementById('computedUrl');
       link.setAttribute('href', urlString);
-      // link.textContent = urlString;
     })
   }
   const updateArtifacts = () => {


### PR DESCRIPTION
Fixes
* #5 

* Add back a DDEV_ARTIFACTS field and send it in the URL
* Update the back-end logic to respect it

## Review

You can experiment with this at https://rfay.github.io/ddev-gitpod-launcher/

<a href="https://gitpod.io/#https://github.com/drud/ddev-gitpod-launcher/pull/7"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

