### PR TITLE
Replace underscore with slash for reponame so ddev config --auto does…

### DIFF
--- a/.gitpod/start_repo.sh
+++ b/.gitpod/start_repo.sh
@@ -9,6 +9,7 @@ export DDEV_REPO=${DDEV_REPO:-https://github.com/drud/d9simple}
 DDEV_ARTIFACTS=${DDEV_REPO}-artifacts
 git clone ${DDEV_ARTIFACTS} "/tmp/${DDEV_ARTIFACTS##*/}" || true
 reponame=${DDEV_REPO##*/}
+reponame="${reponame//_/-}"
 git clone ${DDEV_REPO} ${GITPOD_REPO_ROOT}/${reponame}
 if [ -d ${GITPOD_REPO_ROOT}/${reponame} ]; then
   "$GITPOD_REPO_ROOT"/.gitpod/setup_vscode_git.sh


### PR DESCRIPTION
Some git repositories may contain an underscore `_`. This makes command `ddev config --auto` fail because underscore is not allowed for host names.

You can see this issue for example if you try to open repository https://github.com/goalgorilla/open_social.

As a quick fix I added a simple string replace for all underscores to simple slashes.

**PS**. This may be a problem with the main command `ddev config --auto` but since I could not touch the Go code there I made this small change here.

<a href="https://gitpod.io/#https://github.com/drud/ddev-gitpod-launcher/pull/13"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

