### PR TITLE
Use tagged image to convince gitpod we want it, fixes #22

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: drud/ddev-gitpod-base:latest
+image: drud/ddev-gitpod-base:20220715
 
 tasks:
   - name: ddev-gitpod-launcher


### PR DESCRIPTION
This should be the fix to 
* #22 

I think using the "latest" tag will always be a fail. 

See https://github.com/drud/ddev/pull/4002

<a href="https://gitpod.io/#https://github.com/drud/ddev-gitpod-launcher/pull/23"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

