### PR TITLE
Do an apt-get upgrade on ddev in prebuild

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,6 +3,7 @@ image: drud/ddev-gitpod-base:20220718
 tasks:
   - name: ddev-gitpod-launcher
     init: |
+      apt-get update >/dev/null && apt-get install -y ddev >/dev/null
       cd /tmp && ddev config --auto
       ddev debug download-images
       ddev delete -Oy tmp

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -3,7 +3,6 @@ image: drud/ddev-gitpod-base:20220718
 tasks:
   - name: ddev-gitpod-launcher
     init: |
-      apt-get update >/dev/null && apt-get install -y ddev >/dev/null
       cd /tmp && ddev config --auto
       ddev debug download-images
       ddev delete -Oy tmp

--- a/.gitpod/start_repo.sh
+++ b/.gitpod/start_repo.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu 
+set -eu
 
 # Set up a given DDEV_REPO repository in gitpod (default to d9simple)
 # Run composer install if there's a composer.json
@@ -18,7 +18,7 @@ if [ -d ${GITPOD_REPO_ROOT}/${reponame} ]; then
   "$GITPOD_REPO_ROOT"/.gitpod/setup_vscode_git.sh
   cd ${GITPOD_REPO_ROOT}/${reponame}
   # Temporarily use an empty config.yaml to get ddev to use defaults
-  # so we can do composer install. If there's already one there, 
+  # so we can do composer install. If there's already one there,
   # this does no harm.
   mkdir -p .ddev && touch .ddev/config.yaml
 
@@ -48,7 +48,7 @@ if [ -d ${GITPOD_REPO_ROOT}/${reponame} ]; then
       echo "No files.tgz was provided in /tmp/${DDEV_ARTIFACTS##*/}"
     fi
   fi
-  gp await-port 8080 && sleep 1 && gp preview $(gp url 8080)
+  gp ports await 8080 && sleep 1 && gp preview $(gp url 8080)
 else
   echo "Failed to clone ${DDEV_REPO}, not starting project"
 fi


### PR DESCRIPTION
I think just doing an `apt-get update` with `apt-get install -y ddev` we'll always have latest ddev. Fixes #22 perhaps permanently. /cc @tyler36

<a href="https://gitpod.io/#https://github.com/drud/ddev-gitpod-launcher/pull/24"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

